### PR TITLE
patches line 9 quotes error

### DIFF
--- a/source/ch-communities-and-collaboration/sec-the-issue-tracker.ptx
+++ b/source/ch-communities-and-collaboration/sec-the-issue-tracker.ptx
@@ -425,7 +425,7 @@
       <task xml:id="ex-claim-an-issue-b" label="ex-claim-an-issue-b">
         <statement>
           <p>
-            Comment on the issue that you chose using the <xref ref="topic-issue-claim-message" text="type-global-title">message above</xref> to claim it.
+            Comment on the issue that you chose using the <xref ref="topic-issue-claim-message" text="custom">message above</xref> to claim it.
           </p>
         </statement>
 
@@ -434,7 +434,7 @@
             Click on the issue title to open the issue and use the "Add a comment" box at the bottom of the page. 
           </p>
           <p>
-            Remember you must type <xref ref="topic-issue-claim-message" text="type-global-title">the message</xref> exactly as shown.
+            Remember you must type <xref ref="topic-issue-claim-message" text="custom">the message</xref> exactly as shown.
           </p>
         </hint>
       </task>
@@ -451,7 +451,7 @@
           <p>
             If you did not receive a response, wait a few minutes and reload the issue tracker page again.
             Sometimes it takes a few minutes for your comment to be noticed and the issue to be assigned.
-            If you still do not receive a response check that you typed <xref ref="topic-issue-claim-message" text="type-global-title">the message</xref> correctly.
+            If you still do not receive a response check that you typed <xref ref="topic-issue-claim-message" text="custom">the message</xref> correctly.
           </p>
 
           <p>

--- a/source/ch-upstreaming-changes/sec-creating-a-feature-branch.ptx
+++ b/source/ch-upstreaming-changes/sec-creating-a-feature-branch.ptx
@@ -6,7 +6,7 @@
   <introduction>
     <p>
       When you set out to make changes to the project you will do so by working on a feature branch.
-      The exercises in this section will walk you through the process of creating a feature branch on which you will fix the issue that you claimed in <xref ref="topic-the-issue-tracker text="type-global-title"" />.
+      The exercises in this section will walk you through the process of creating a feature branch on which you will fix the issue that you claimed in <xref ref="topic-the-issue-tracker" text="type-global-title" />.
     </p>
 
     <p>


### PR DESCRIPTION
**Pull Request Description**

Fixes a misplaced quote, and issues with the `text` attribute on some `xrefs` that pointed to the "I would like to work on this!" text rather than a numbered section and had custom text for the `xref`.

This allows the project to build without error.  However, the CodeChat preview still does not seem to be working.  Will debug that separately.

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.