### PR TITLE
Add width attribute % to giant images

### DIFF
--- a/source/ch-communities-and-collaboration/sec-the-issue-tracker.ptx
+++ b/source/ch-communities-and-collaboration/sec-the-issue-tracker.ptx
@@ -148,66 +148,78 @@
         <choices randomize="yes">
           <choice correct="yes">
             <statement>
-              <image source="images/ch-communities-and-collaboration/documentation-tag.png">
+              <p>
+              <image source="images/ch-communities-and-collaboration/documentation-tag.png" width="25%">
                 <shortdescription>
                   Image of the Documentation label.
                 </shortdescription>
               </image>
+              </p>
             </statement>
 
           </choice>
 
           <choice correct="yes">
             <statement>
-              <image source="images/ch-communities-and-collaboration/round1-tag.png">
+             <p>
+              <image source="images/ch-communities-and-collaboration/round1-tag.png" width="15%">
                 <shortdescription>
                   Image of the Round1 label.
                 </shortdescription>
               </image>
+              </p>
             </statement>
 
           </choice>
 
           <choice correct="yes">
             <statement>
-              <image source="images/ch-communities-and-collaboration/enhancement-tag.png">
+             <p>
+              <image source="images/ch-communities-and-collaboration/enhancement-tag.png" width="25%">
                 <shortdescription>
                   Image of the Enhancement label.
                 </shortdescription>
               </image>
+             </p>
             </statement>
 
           </choice>
 
           <choice correct="no">
             <statement>
-              <image source="images/ch-communities-and-collaboration/typos-tag.png">
+             <p>
+              <image source="images/ch-communities-and-collaboration/typos-tag.png" width="10%">
                 <shortdescription>
                   Image of the Typos label.
                 </shortdescription>
               </image>
+             </p>
             </statement>
 
           </choice>
 
           <choice correct="no">
             <statement>
-              <image source="images/ch-communities-and-collaboration/bug-tag.png">
+             <p>
+              <image source="images/ch-communities-and-collaboration/bug-tag.png" width="10%">
                 <shortdescription>
                   Image of the Bug label.
                 </shortdescription>
               </image>
+              </p>
             </statement>
 
           </choice>
 
           <choice correct="no">
             <statement>
-              <image source="images/ch-communities-and-collaboration/uiux-tag.png">
+             <p>
+              <image source="images/ch-communities-and-collaboration/uiux-tag.png" width="15%">
                 <shortdescription>
                   Image of the UI/UX label.
                 </shortdescription>
               </image>
+             </p>
             </statement>
 
           </choice>


### PR DESCRIPTION
**Pull Request Description**

Added width attribute with %  values to giant images .  Also added  \<p\> tags which might help.
Closes  issue https://github.com/HFOSSedu/GitKit-Codespace/issues/127
Tested these widths in Chrome and Firefox.

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.